### PR TITLE
Fix the issue where codePath is not set

### DIFF
--- a/src/main/java/com/ly/doc/gradle/task/DocBaseTask.java
+++ b/src/main/java/com/ly/doc/gradle/task/DocBaseTask.java
@@ -34,6 +34,7 @@ import com.ly.doc.gradle.util.ArtifactFilterUtil;
 import com.ly.doc.gradle.util.GradleUtil;
 import com.ly.doc.gradle.util.I18nMsgUtil;
 import com.ly.doc.gradle.util.SourceSetUtil;
+import com.power.common.util.StringUtil;
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.library.SortedClassLibraryBuilder;
 import org.gradle.api.DefaultTask;
@@ -107,6 +108,9 @@ public abstract class DocBaseTask extends DefaultTask {
         if (apiConfig == null) {
             logger.quiet(GlobalConstants.ERROR_MSG);
             return;
+        }
+        if (StringUtil.isEmpty(apiConfig.getCodePath())) {
+            apiConfig.setCodePath(GlobalConstants.SRC_MAIN_JAVA_PATH);
         }
         if (Objects.nonNull(apiConfig.getRpcConsumerConfig())) {
             Path rpcConsumerPath = Paths.get(apiConfig.getRpcConsumerConfig());


### PR DESCRIPTION
Fix the error of gradle 3.0.1 plugin
修正gradle 3.0.1插件报错
![1b201c09d408a4f383b38d23e9c7a636](https://github.com/TongchengOpenSource/smart-doc-gradle-plugin/assets/5616997/6d73b470-c065-49bc-8080-1faced62c494)
